### PR TITLE
Ensure positive size is passed to bzalloc

### DIFF
--- a/src/graphical-volmeter.c
+++ b/src/graphical-volmeter.c
@@ -311,6 +311,7 @@ static uint32_t get_height(void *data)
 
 static gs_vertbuffer_t *create_vbuf(uint32_t n)
 {
+	assert(n > 0);
 	struct gs_vb_data *vrect = gs_vbdata_create();
 	vrect->num = n;
 	vrect->points = bzalloc(sizeof(struct vec3) * n);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Add an assetion to ensure the size to allocate is always positive.

The value is always positive for current implementation but I want to ensure future changes does not break this.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Checked every places that calls `create_vbuf` by eyes.

CI will test the build flow.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
